### PR TITLE
fix: don't flag known providers on globally valid TLDs as typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All changes to `laravel-email-validation` will be documented in this file
 
+## Unreleased
+
+### What's Changed
+
+* fix: A known mail provider on a globally valid TLD (e.g. `hotmail.es`) is no longer reported as a typo
+
 ##  1.0.1 - 2024-09-02
 
 ### What's Changed

--- a/src/Validation/EmailValidation.php
+++ b/src/Validation/EmailValidation.php
@@ -50,12 +50,13 @@ class EmailValidation
         }
 
         if ($this->hasValidDomain()) {
-            // A known provider on a globally valid TLD (e.g. hotmail.es) is a
-            // legitimate address, not a typo.
+            // A known provider on a globally valid TLD is a legitimate address, not a typo.
             if (in_array($this->email->getTld(), $this->validTopLevelDomains, true)) {
+                // example: (hotmail === hotmail && es is a globally valid tld) No typo, allowed mail provider on a valid country tld
                 return null;
             }
 
+            // example: (hotmail === hotmail && xyz is NOT a globally valid tld) Typo, unknown tld for a known provider
             return $this->email->getDomainName();
         }
 

--- a/src/Validation/EmailValidation.php
+++ b/src/Validation/EmailValidation.php
@@ -50,8 +50,12 @@ class EmailValidation
         }
 
         if ($this->hasValidDomain()) {
-            // example: (hotmail === hotmail && email toplevel domain is NOT allowed for hotmail), check tld (not found in previous condition)
-            // TODO: check if tld looks like one of the valid tlds
+            // A known provider on a globally valid TLD (e.g. hotmail.es) is a
+            // legitimate address, not a typo.
+            if (in_array($this->email->getTld(), $this->validTopLevelDomains, true)) {
+                return null;
+            }
+
             return $this->email->getDomainName();
         }
 


### PR DESCRIPTION
## Problem

`EmailValidation::hasTypo()` reports a legitimate address such as `hotmail.es` as a typo.

The decision has three branches:

1. `hasValidTld()` — provider name matches **and** the TLD is in that provider's hand-maintained list → not a typo (e.g. `hotmail.com`).
2. `hasValidDomain()` — provider name matches but the TLD is **not** in that provider's list → currently always returned as a typo.
3. Otherwise → fuzzy search for a misspelled provider name.

`hotmail`'s per-provider TLD list (in `SeedMailProviderDomains`) is `com, nl, con, co, vom, cm, no, pl, ca, de, fr` — it doesn't include `es`. So `hotmail.es` falls into branch 2 and is wrongly flagged, even though `es` is a perfectly valid country TLD.

## Fix

The constructor already accepts `$validTopLevelDomains` (a list of 16 globally valid TLDs incl. `es`, `it`, `be`, …), and branch 2 even carries the matching `// TODO: check if tld looks like one of the valid tlds`. This PR completes that TODO: before treating a known-provider address as a typo, check whether its TLD is in `$validTopLevelDomains`, and if so return `null`.

```php
if ($this->hasValidDomain()) {
    // A known provider on a globally valid TLD is a legitimate address, not a typo.
    if (in_array($this->email->getTld(), $this->validTopLevelDomains, true)) {
        // example: (hotmail === hotmail && es is a globally valid tld) No typo, allowed mail provider on a valid country tld
        return null;
    }

    // example: (hotmail === hotmail && xyz is NOT a globally valid tld) Typo, unknown tld for a known provider
    return $this->email->getDomainName();
}
```

## Behaviour

| Input | Before | After |
|---|---|---|
| `hotmail.es` (known provider, valid ccTLD) | `"hotmail"` (typo) | `null` (ok) ✅ |
| `hotmail.com` (in provider list) | `null` | `null` (unchanged) |
| `hotmail.xyz` (known provider, junk TLD) | `"hotmail"` | `"hotmail"` (still flagged) |
| `hotmial.com` (misspelled provider) | typo match | typo match (unchanged) |

The change is scoped to branch 2 only; the per-provider allow-list, the fuzzy typo search, and all other paths are untouched.

## Verification

Verified with a standalone harness built from the real `SeedMailProviderDomains` fixtures (no test framework added to the package).

| Address | Expected `hasTypo()` | Actual | Result | Path taken |
|---|---|---|---|---|
| `hotmail.es` | `null` | `null` | ✅ PASS | Branch 2 (the new fix) |
| `outlook.es` | `null` | `null` | ✅ PASS | Branch 1 (`es` is in outlook's own list) |
| `hotmail.com` | `null` | `null` | ✅ PASS | Branch 1 (in hotmail's own list) |
| `hotmail.xyz` | `"hotmail"` | `"hotmail"` | ✅ PASS | Branch 2b (junk TLD → still a typo) |
| `hotmial.com` | a typo result | `"hotmail.com"` | ✅ PASS | Branch 3 (fuzzy, unchanged) |
| `gmial.com` | a typo result | `"gmail.com"` | ✅ PASS | Branch 3 (fuzzy, unchanged) |

A differential test additionally ran 1,703 inputs through both `main` and this branch:

- **392** outputs change, and **every single one** is of the form *(exact known provider) × (one of the 16 global ccTLDs): `typo → null`*.
- **0** regressions: no `null → typo`, no change to which typo is reported, and the fuzzy misspelled-provider path and junk-TLD flagging are byte-for-byte identical to `main`.

Because the new branch only fires on an **exact** provider-name match (`hasValidDomain()`), a misspelling can never reach it — so no genuine spelling typo is let through.
