### PR TITLE
Add missing valid ccTLDs for hotmail (es) and outlook (pt)

### DIFF
--- a/src/Commands/SeedMailProviderDomains.php
+++ b/src/Commands/SeedMailProviderDomains.php
@@ -47,7 +47,7 @@ class SeedMailProviderDomains extends Command
         }
 
         $domainsThatShouldBeCheckedOnTypo = [
-            [MailProviderDomain::DOMAIN_NAME => 'hotmail', MailProviderDomain::TLD => '["com", "nl", "con", "co", "vom", "cm", "no", "pl", "ca", "de", "fr"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
+            [MailProviderDomain::DOMAIN_NAME => 'hotmail', MailProviderDomain::TLD => '["com", "nl", "con", "co", "vom", "cm", "no", "pl", "ca", "de", "fr", "es"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
             [MailProviderDomain::DOMAIN_NAME => 'gmail', MailProviderDomain::TLD => '["com", "nl", "con", "co", "vom", "cm", "it"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
             [MailProviderDomain::DOMAIN_NAME => 'yahoo', MailProviderDomain::TLD => '["com", "ie", "in", "ro", "nl", "fr", "de", "es", "be", "at", "dk", "fi", "gr", "se", "it", "pl", "ca"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
             [MailProviderDomain::DOMAIN_NAME => 'ziggo', MailProviderDomain::TLD => '["nl", "com", "fr", "at", "se"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
@@ -58,7 +58,7 @@ class SeedMailProviderDomains extends Command
             [MailProviderDomain::DOMAIN_NAME => 'kpnmail', MailProviderDomain::TLD => '["nl", "es"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
             [MailProviderDomain::DOMAIN_NAME => 'planet', MailProviderDomain::TLD => '["nl", "uk", "de", "gr"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
             [MailProviderDomain::DOMAIN_NAME => 'vodafone', MailProviderDomain::TLD => '["nl", "com", "de", "es", "it"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
-            [MailProviderDomain::DOMAIN_NAME => 'outlook', MailProviderDomain::TLD => '["nl", "com", "fr", "de", "es", "be", "at", "dk", "gr", "se", "it", "pl"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
+            [MailProviderDomain::DOMAIN_NAME => 'outlook', MailProviderDomain::TLD => '["nl", "com", "fr", "de", "es", "be", "at", "dk", "gr", "se", "it", "pl", "pt"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
             [MailProviderDomain::DOMAIN_NAME => 'telenet', MailProviderDomain::TLD => '["be", "uk", "at", "dk", "fi", "ru"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
             [MailProviderDomain::DOMAIN_NAME => 'tiscali', MailProviderDomain::TLD => '["nl", "com", "it"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],
             [MailProviderDomain::DOMAIN_NAME => 'telfort', MailProviderDomain::TLD => '["nl", "com", "es", "at", "it", "pl"]', MailProviderDomain::POPULAR => true, MailProviderDomain::CREATED_AT => now(), MailProviderDomain::UPDATED_AT => now(), ],


### PR DESCRIPTION
## Problem

A known mail provider used with a valid country-code TLD that isn't in that provider's seeded allow-list is reported as a typo. In `EmailValidation::hasTypo()` the provider name matches (`hasValidDomain()` is true), but the TLD isn't in the provider's list, so it falls through to the branch that returns the domain name as the "typo".

The result is that legitimate addresses are rejected, for example:

- `user@hotmail.es` → flagged as typo `"hotmail"` (hotmail's list had no `es`)
- `user@outlook.pt` → flagged as typo `"outlook"` (outlook's list had no `pt`)

Both `hotmail.es` and `outlook.pt` are real, in-use Microsoft domains.

## Fix

Add the missing ccTLDs to the seeder:

- `hotmail`: + `es`
- `outlook`: + `pt`

Data-only change — no logic change. Junk TLDs (e.g. `hotmail.xyz`) are still correctly flagged, and the fuzzy misspelling detection is unaffected.

## Verification

Against a generated adversarial corpus (every seeded provider × a wide TLD probe set, plus misspelled-provider variants), only the intended addresses change behaviour: `*@hotmail.es` and `*@outlook.pt` now return `null` (not a typo), while every other result — including all junk-TLD and fuzzy-typo cases — is unchanged.

## Note for existing installs

The seeder truncates and re-inserts, so existing deployments need to re-run `silassiai-email-validation:seed` (or otherwise add the new TLDs) to pick up the change.
