### PR TITLE
test: add PHPUnit suite + property-setter refactor (supersedes #5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 composer.phar
+composer.lock
 /vendor/
 
 .idea/
+
+.phpunit.cache/
+.phpunit.result.cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# laravel-email-validation — Project Rules
+
+## Testing
+
+- **Never use real registered domains as test fixtures.** In particular, do **not** use `telepac` / `telepac.pt` (a real ISP) anywhere under `tests/`. Use reserved placeholder domains — `example.com`, `example.org`, `example.net` (RFC 2606) — for subdomain/parsing fixtures instead.
+- Tests are **pure PHPUnit** (no Laravel boot / no Testbench) and cover **only the code a change modifies**. Full-corpus behavior is verified with the external lev-harness differential, not additional in-repo tests.

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
             "Silassiai\\LaravelEmailValidation\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Silassiai\\LaravelEmailValidation\\Tests\\": "tests/"
+        }
+    },
     "authors": [
         {
             "name": "Silas de Rooy",
@@ -36,5 +41,9 @@
     ],
     "require": {
         "php": "^8"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5 || ^11.5 || ^12.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Validation/Email.php
+++ b/src/Validation/Email.php
@@ -36,20 +36,35 @@ class Email
     }
 
     /**
+     * The non-empty dot-separated labels of the domain
+     * @return string[]
+     */
+    private function labels(): array
+    {
+        return array_values(array_filter(explode('.', $this->domain), static fn ($label) => $label !== ''));
+    }
+
+    /**
+     * The registrable domain name: the label left of the top level domain
      * @return $this
      */
     private function setDomainName(): self
     {
-        $this->domainName = Str::before($this->domain, '.');
+        $labels = $this->labels();
+        $count = count($labels);
+        $this->domainName = $count >= 2 ? $labels[$count - 2] : ($labels[0] ?? '');
         return $this;
     }
 
     /**
+     * The top level domain: the last label of the domain
      * @return $this
      */
     private function setTopLevelDomain(): self
     {
-        $this->tld = Str::after($this->domain, '.');
+        $labels = $this->labels();
+        $count = count($labels);
+        $this->tld = $count >= 2 ? $labels[$count - 1] : '';
         return $this;
     }
 

--- a/src/Validation/Email.php
+++ b/src/Validation/Email.php
@@ -22,8 +22,7 @@ class Email
         $this->email = strtolower($email);
         $this
             ->setDomain()
-            ->setDomainName()
-            ->setTopLevelDomain();
+            ->setRegistrableDomain();
     }
 
     /**
@@ -36,34 +35,16 @@ class Email
     }
 
     /**
-     * The non-empty dot-separated labels of the domain
-     * @return string[]
-     */
-    private function labels(): array
-    {
-        return array_values(array_filter(explode('.', $this->domain), static fn ($label) => $label !== ''));
-    }
-
-    /**
-     * The registrable domain name: the label left of the top level domain
+     * Parse the registrable domain from the non-empty dot-separated labels of
+     * the domain: the top level domain is the last label, the domain name the
+     * label to its left. Subdomains are ignored.
      * @return $this
      */
-    private function setDomainName(): self
+    private function setRegistrableDomain(): self
     {
-        $labels = $this->labels();
+        $labels = array_values(array_filter(explode('.', $this->domain), static fn ($label) => $label !== ''));
         $count = count($labels);
         $this->domainName = $count >= 2 ? $labels[$count - 2] : ($labels[0] ?? '');
-        return $this;
-    }
-
-    /**
-     * The top level domain: the last label of the domain
-     * @return $this
-     */
-    private function setTopLevelDomain(): self
-    {
-        $labels = $this->labels();
-        $count = count($labels);
         $this->tld = $count >= 2 ? $labels[$count - 1] : '';
         return $this;
     }

--- a/src/Validation/Email.php
+++ b/src/Validation/Email.php
@@ -16,13 +16,26 @@ class Email
      */
     private string $tld;
 
+    /** @var string $email */
+    public string $email;
+
     public function __construct(
-        public string $email,
+        string $email,
     ) {
-        $this->email = strtolower($email);
         $this
+            ->setEmail($email)
             ->setDomain()
             ->setRegistrableDomain();
+    }
+
+    /**
+     * @param string $email
+     * @return static
+     */
+    private function setEmail(string $email): self
+    {
+        $this->email = strtolower($email);
+        return $this;
     }
 
     /**

--- a/src/Validation/EmailValidation.php
+++ b/src/Validation/EmailValidation.php
@@ -26,6 +26,15 @@ class EmailValidation
      */
     public function for(string $email): self
     {
+        return $this->setEmail($email);
+    }
+
+    /**
+     * @param string $email
+     * @return $this
+     */
+    private function setEmail(string $email): self
+    {
         $this->email = new Email($email);
         return $this;
     }
@@ -81,7 +90,7 @@ class EmailValidation
      *
      * @return EmailValidation
      */
-    public function setCharacterDiffLevel(): self
+    private function setCharacterDiffLevel(): self
     {
         $this->characterDiffLevel = (strlen($this->email->getDomainName()) > 6) ? 2 : 1;
         return $this;

--- a/tests/Unit/EmailTest.php
+++ b/tests/Unit/EmailTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Silassiai\LaravelEmailValidation\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Silassiai\LaravelEmailValidation\Validation\Email;
+
+class EmailTest extends TestCase
+{
+    public function testNormalizesToLowercaseAndParsesTwoLabelDomain(): void
+    {
+        $email = new Email('FOO@BAR.COM');
+
+        $this->assertSame('foo@bar.com', $email->email);
+        $this->assertSame('bar.com', $email->getDomain());
+        $this->assertSame('bar', $email->getDomainName());
+        $this->assertSame('com', $email->getTld());
+    }
+
+    public function testParsesPlainTwoLabelDomain(): void
+    {
+        $email = new Email('a@bar.com');
+
+        $this->assertSame('bar', $email->getDomainName());
+        $this->assertSame('com', $email->getTld());
+    }
+
+    public function testUsesRegistrableDomainForSubdomains(): void
+    {
+        $email = new Email('a@sub.example.org');
+
+        $this->assertSame('example', $email->getDomainName());
+        $this->assertSame('org', $email->getTld());
+    }
+
+    public function testHandlesSingleLabelDomainWithoutTld(): void
+    {
+        $email = new Email('a@localhost');
+
+        $this->assertSame('localhost', $email->getDomainName());
+        $this->assertSame('', $email->getTld());
+    }
+
+    public function testIgnoresTrailingDotEmptyLabels(): void
+    {
+        $email = new Email('a@bar.com.');
+
+        $this->assertSame('bar', $email->getDomainName());
+        $this->assertSame('com', $email->getTld());
+    }
+}

--- a/tests/Unit/EmailValidationTest.php
+++ b/tests/Unit/EmailValidationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Silassiai\LaravelEmailValidation\Tests\Unit;
+
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
+use Silassiai\LaravelEmailValidation\Services\MailProviderDomainService;
+use Silassiai\LaravelEmailValidation\Validation\EmailValidation;
+
+class EmailValidationTest extends TestCase
+{
+    private function makeValidation(): EmailValidation
+    {
+        $all = new Collection(['hotmail' => ['com', 'nl']]);
+
+        return new EmailValidation(
+            new MailProviderDomainService($all),
+            new MailProviderDomainService($all),
+            new MailProviderDomainService(new Collection([]))
+        );
+    }
+
+    public function testForWiresUpNormalizedEmail(): void
+    {
+        $validation = $this->makeValidation();
+
+        $this->assertTrue($validation->for('User@Hotmail.com')->hasValidDomain());
+    }
+
+    public function testForReturnsFalseForUnknownDomain(): void
+    {
+        $validation = $this->makeValidation();
+
+        $this->assertFalse($validation->for('x@example.com')->hasValidDomain());
+    }
+}


### PR DESCRIPTION
## Summary

This PR **supersedes #5**. It carries #5's registrable-domain parser fix (commits `9cb5788`, `037c20a`) and adds the package's **first in-repo test suite** plus a small, behavior-preserving refactor of the property-setting seams. #5 will be closed in favour of this one.

## What's included

1. **Parser fix (from #5)** — `hasTypo()` no longer false-flags 3+-label hosts / two-part TLDs. The host is parsed by its *registrable domain* (last two labels). Full rationale and evidence in #5.
2. **New — minimal PHPUnit suite** (pure PHPUnit, no Laravel boot / no Testbench). The package previously had no in-repo tests.
3. **New — property-setter refactor** (behavior-preserving): inline property assignment is extracted into private `setEmail()` methods, matching the existing `setDomain()` / `setRegistrableDomain()` pattern.

## Refactor (behavior-preserving)

- **`Email`** — promoted `public string $email` becomes a declared property + a private `setEmail()` that lowercases; the constructor now reads `setEmail()->setDomain()->setRegistrableDomain()`. `$email` stays publicly readable.
- **`EmailValidation`** — `for()` delegates to a private `setEmail()`; `setCharacterDiffLevel()` (only ever called internally) is now `private`.

No public behavior changes; `getDomain()`/`getDomainName()`/`getTld()` and the typo algorithm are untouched.

## Test suite (`tests/Unit/`)

Scoped to **only the code this change modifies** — the property-setting seams. The typo algorithm (`hasTypo`/`foundTypo`/`passFirstCharacters`) and `MailProviderDomainService` are not re-tested; their behavior across the refactor is locked by the differential below.

- **`EmailTest`** — lowercasing + registrable-domain parsing (2-label, subdomain, no-dot, trailing-dot) via the public getters.
- **`EmailValidationTest`** — `for()` / `setEmail()` wiring, observed through `hasValidDomain()`, using in-memory `Collection`s wired exactly like `EmailValidationServiceProvider`.

## Verification

- `vendor/bin/phpunit` → **OK (7 tests, 14 assertions)** on PHP 8.4 / PHPUnit 12.
- **Refactor no-op proof:** the standalone differential harness (`diff_runner_ext.php`, same wiring as the service provider, real seed fixtures) was run over a **1,839-address corpus** against the tree *before* and *after* the property-setter refactor → **byte-identical**. So the refactor changes zero behavior on the (deliberately un-unit-tested) typo paths.

## Scope / notes

- `composer.lock` is git-ignored (library convention); dev-dep constraints use broad `||` ranges so Composer resolves PHPUnit/illuminate per PHP version (10/11/12).
- A `CLAUDE.md` is added with the project's test conventions (no real registered domains as fixtures; use RFC 2606 `example.*` placeholders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
